### PR TITLE
Fix namespace of package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "spryker/b2c-demo-shop",
+    "name": "spryker-shop/b2c-demo-shop",
     "description": "Spryker B2C Demo Shop",
     "license": "proprietary",
     "require": {


### PR DESCRIPTION
Release App tooling warns very clearly about this
Please fix this also for other repos and make sure this does not happen again

The docs and alike also mention proper naming as per our rules.