### PR TITLE
Clean up phpstan.neon

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,11 +3,11 @@ includes:
 
 parameters:
     excludePaths:
-        - %rootDir%/../../../src/Generated/*
-        - %rootDir%/../../../src/Orm/*
+        - src/Generated/*
+        - src/Orm/*
 
     bootstrapFiles:
-        - %rootDir%/../../../phpstan-bootstrap.php
+        - phpstan-bootstrap.php
 
     ignoreErrors:
         - '#Call to an undefined method .+Criteria::.+\(\).#'


### PR DESCRIPTION
Relative paths are resolved based on the location of the configuration file they're in.