### PR TITLE
SDK-2897: Add integrator.lock file to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,7 @@ composer.phar
 c3.php
 .phpstorm.meta.php
 .githook_local
+integrator.lock
 
 # Yarn
 .yarn/*


### PR DESCRIPTION
#### Overview

- Ticket: [SDK-2897](https://spryker.atlassian.net/browse/SDK-2897)

###### Change log

- Add integrator.lock file to .gitignore