### PR TITLE
FRW-6374: Removed propel loaderScriptDir property.

### DIFF
--- a/config/Shared/config_propel.php
+++ b/config/Shared/config_propel.php
@@ -84,7 +84,6 @@ $config[PropelConstants::PROPEL] = [
         'sqlDir' => APPLICATION_ROOT_DIR . '/src/Orm/Propel/Sql',
         'migrationDir' => APPLICATION_ROOT_DIR . '/src/Orm/Propel/Migration_' . $config[PropelConstants::ZED_DB_ENGINE],
         'schemaDir' => APPLICATION_ROOT_DIR . '/src/Orm/Propel/Schema',
-        'loaderScriptDir' => APPLICATION_ROOT_DIR . '/src/Orm/Propel/generated-conf/',
     ],
 ];
 


### PR DESCRIPTION
#### Overview

- Ticket: [FRW-6374](https://spryker.atlassian.net/browse/FRW-6374)

###### Optional

- Core PR: - no core PR since it is a clean-up to sync demo-shops

###### Change log

Remove loaderScriptDir property from propel config (to use default)
