### PR TITLE
FRW-6379: Synchronize cors-allow-origin property

### DIFF
--- a/deploy.dev.yml
+++ b/deploy.dev.yml
@@ -110,13 +110,16 @@ groups:
                         cors-allow-origin: '*'
                     glue.at.spryker.local:
                         store: AT
+                        cors-allow-origin: '*'
             glue_storefront_eu:
                 application: glue-storefront
                 endpoints:
                     glue-storefront.de.spryker.local:
                         store: DE
+                        cors-allow-origin: '*'
                     glue-storefront.at.spryker.local:
                         store: AT
+                        cors-allow-origin: '*'
             glue_backend_eu:
                 application: glue-backend
                 endpoints:
@@ -124,8 +127,8 @@ groups:
                         store: DE
                         cors-allow-origin: '*'
                     glue-backend.at.spryker.local:
-                        store:
-                            AT
+                        store: AT
+                        cors-allow-origin: '*'
             backoffice_eu:
                 application: backoffice
                 endpoints:
@@ -173,16 +176,19 @@ groups:
                 endpoints:
                     glue.us.spryker.local:
                         store: US
+                        cors-allow-origin: '*'
             glue_storefront_us:
                 application: glue-storefront
                 endpoints:
                     glue-storefront.us.spryker.local:
                         store: US
+                        cors-allow-origin: '*'
             glue_backend_us:
                 application: glue-backend
                 endpoints:
                     glue-backend.us.spryker.local:
                         store: US
+                        cors-allow-origin: '*'
             backoffice_us:
                 application: backoffice
                 endpoints:


### PR DESCRIPTION
#### Overview

- Ticket: https://spryker.atlassian.net/browse/FRW-6379

###### Optional

- suite-nonsplit PR: https://github.com/spryker/suite-nonsplit/pull/8337

###### Change log

- Adding `cors-allow-origin` property to all glue endpoints in `deploy.dev.yml`.