### PR TITLE
Update Jenkins version to 2.493.2

### DIFF
--- a/deploy.aop-b2c-testing.yml
+++ b/deploy.aop-b2c-testing.yml
@@ -221,6 +221,7 @@ services:
                 protocol: tcp
     scheduler:
         engine: jenkins
+        version: '2.492.3'
         csrf-protection-enabled: true
         endpoints:
             jenkins.aop-b2c-testing.demo-spryker.com:

--- a/deploy.aop-consultant-b2c.yml
+++ b/deploy.aop-consultant-b2c.yml
@@ -221,6 +221,7 @@ services:
                 protocol: tcp
     scheduler:
         engine: jenkins
+        version: '2.492.3'
         csrf-protection-enabled: true
         endpoints:
             scheduler.consultant-b2c.demo-spryker.com:

--- a/deploy.aop-demoshop-b2c.yml
+++ b/deploy.aop-demoshop-b2c.yml
@@ -181,6 +181,7 @@ services:
                 protocol: tcp
     scheduler:
         engine: jenkins
+        version: '2.492.3'
         csrf-protection-enabled: true
         endpoints:
             scheduler.aop-b2c.demo-spryker.com:

--- a/deploy.aws-env-template.yml
+++ b/deploy.aws-env-template.yml
@@ -167,7 +167,7 @@ services:
                 protocol: tcp
     scheduler:
         engine: jenkins
-        version: '2.442'
+        version: '2.492.3'
         csrf-protection-enabled: true
         endpoints:
             scheduler.example.demo-spryker.com:

--- a/deploy.ci.acceptance.mariadb.prefer-lowest.yml
+++ b/deploy.ci.acceptance.mariadb.prefer-lowest.yml
@@ -116,7 +116,7 @@ services:
         version: '6.8'
     scheduler:
         engine: jenkins
-        version: '2.442'
+        version: '2.492.3'
         csrf-protection-enabled: true
     mail_catcher:
         engine: mailhog

--- a/deploy.ci.functional.mariadb.prefer-lowest.yml
+++ b/deploy.ci.functional.mariadb.prefer-lowest.yml
@@ -115,7 +115,7 @@ services:
         version: '6.8'
     scheduler:
         engine: jenkins
-        version: '2.442'
+        version: '2.492.3'
         csrf-protection-enabled: true
     mail_catcher:
         engine: mailhog

--- a/deploy.dev.dynamic-store-off.yml
+++ b/deploy.dev.dynamic-store-off.yml
@@ -242,7 +242,7 @@ services:
                 protocol: tcp
     scheduler:
         engine: jenkins
-        version: '2.442'
+        version: '2.492.3'
         csrf-protection-enabled: true
         endpoints:
             scheduler.spryker.local:

--- a/deploy.dev.yml
+++ b/deploy.dev.yml
@@ -213,7 +213,7 @@ services:
                 protocol: tcp
     scheduler:
         engine: jenkins
-        version: '2.442'
+        version: '2.492.3'
         csrf-protection-enabled: true
         endpoints:
             scheduler.spryker.local:

--- a/deploy.dynamic-store-off.yml
+++ b/deploy.dynamic-store-off.yml
@@ -226,7 +226,7 @@ services:
                 protocol: tcp
     scheduler:
         engine: jenkins
-        version: '2.442'
+        version: '2.492.3'
         csrf-protection-enabled: true
         endpoints:
             scheduler.spryker.local:

--- a/deploy.scos2-b2c.yml
+++ b/deploy.scos2-b2c.yml
@@ -159,7 +159,7 @@ services:
                 protocol: tcp
     scheduler:
         engine: jenkins
-        version: '2.442'
+        version: '2.492.3'
         csrf-protection-enabled: false
         endpoints:
             scheduler.spryker-b2c.cloud.spryker.toys:

--- a/deploy.spryker-dynamicstore.yml
+++ b/deploy.spryker-dynamicstore.yml
@@ -182,7 +182,7 @@ services:
                 protocol: tcp
     scheduler:
         engine: jenkins
-        version: '2.442'
+        version: '2.492.3'
         csrf-protection-enabled: true
         endpoints:
             scheduler.dynamic-store.demo-spryker.com:

--- a/deploy.spryker-scosb2c.yml
+++ b/deploy.spryker-scosb2c.yml
@@ -163,7 +163,7 @@ services:
                 protocol: tcp
     scheduler:
         engine: jenkins
-        version: '2.442'
+        version: '2.492.3'
         endpoints:
             scheduler.scos-b2c.sh01.demo-spryker.com:
         csrf-protection-enabled: true

--- a/deploy.yml
+++ b/deploy.yml
@@ -220,7 +220,7 @@ services:
                 protocol: tcp
     scheduler:
         engine: jenkins
-        version: '2.442'
+        version: '2.492.3'
         csrf-protection-enabled: true
         endpoints:
             scheduler.spryker.local:


### PR DESCRIPTION
#### Overview

- Ticket: https://spryker.atlassian.net/browse/FRW-10275

###### Change log

- Introduce Jenkins 2.492.3 as the default scheduler version.
