### PR TITLE
OPS-4941 Updated RabbitMQ version.

### DIFF
--- a/deploy.aws-env-template.yml
+++ b/deploy.aws-env-template.yml
@@ -144,7 +144,7 @@ services:
                 protocol: tcp
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: "spryker"
             password: "secret"

--- a/deploy.ci.acceptance.dynamic-store-off.yml
+++ b/deploy.ci.acceptance.dynamic-store-off.yml
@@ -141,7 +141,7 @@ services:
                 protocol: tcp
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: "spryker"
             password: "secret"

--- a/deploy.ci.acceptance.mariadb.cypress.yml
+++ b/deploy.ci.acceptance.mariadb.cypress.yml
@@ -112,7 +112,7 @@ services:
                 protocol: tcp
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: 'spryker'
             password: 'secret'

--- a/deploy.ci.acceptance.mariadb.dynamic-store-off.cypress.yml
+++ b/deploy.ci.acceptance.mariadb.dynamic-store-off.cypress.yml
@@ -150,7 +150,7 @@ services:
                 protocol: tcp
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: 'spryker'
             password: 'secret'

--- a/deploy.ci.acceptance.mariadb.dynamic-store-off.robot.yml
+++ b/deploy.ci.acceptance.mariadb.dynamic-store-off.robot.yml
@@ -142,7 +142,7 @@ services:
                 protocol: tcp
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: 'spryker'
             password: 'secret'

--- a/deploy.ci.acceptance.mariadb.dynamic-store-off.yml
+++ b/deploy.ci.acceptance.mariadb.dynamic-store-off.yml
@@ -140,7 +140,7 @@ services:
                 protocol: tcp
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: "spryker"
             password: "secret"

--- a/deploy.ci.acceptance.mariadb.prefer-lowest.yml
+++ b/deploy.ci.acceptance.mariadb.prefer-lowest.yml
@@ -103,7 +103,7 @@ services:
                 protocol: tcp
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: 'spryker'
             password: 'secret'

--- a/deploy.ci.acceptance.mariadb.robot.yml
+++ b/deploy.ci.acceptance.mariadb.robot.yml
@@ -106,7 +106,7 @@ services:
                 protocol: tcp
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: 'spryker'
             password: 'secret'

--- a/deploy.ci.acceptance.mariadb.yml
+++ b/deploy.ci.acceptance.mariadb.yml
@@ -103,7 +103,7 @@ services:
                 protocol: tcp
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: 'spryker'
             password: 'secret'

--- a/deploy.ci.acceptance.robot.yml
+++ b/deploy.ci.acceptance.robot.yml
@@ -99,7 +99,7 @@ services:
             password: 'secret'
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: 'spryker'
             password: 'secret'

--- a/deploy.ci.acceptance.yml
+++ b/deploy.ci.acceptance.yml
@@ -99,7 +99,7 @@ services:
             password: 'secret'
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: 'spryker'
             password: 'secret'

--- a/deploy.ci.api.dynamic-store-off.yml
+++ b/deploy.ci.api.dynamic-store-off.yml
@@ -131,7 +131,7 @@ services:
             password: "secret"
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: "spryker"
             password: "secret"

--- a/deploy.ci.api.mariadb.dynamic-store-off.yml
+++ b/deploy.ci.api.mariadb.dynamic-store-off.yml
@@ -132,7 +132,7 @@ services:
             password: "secret"
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: "spryker"
             password: "secret"

--- a/deploy.ci.api.mariadb.robot.yml
+++ b/deploy.ci.api.mariadb.robot.yml
@@ -102,7 +102,7 @@ services:
                 protocol: tcp
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: 'spryker'
             password: 'secret'

--- a/deploy.ci.api.mariadb.yml
+++ b/deploy.ci.api.mariadb.yml
@@ -92,7 +92,7 @@ services:
             password: 'secret'
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: 'spryker'
             password: 'secret'

--- a/deploy.ci.api.yml
+++ b/deploy.ci.api.yml
@@ -92,7 +92,7 @@ services:
             password: 'secret'
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: 'spryker'
             password: 'secret'

--- a/deploy.ci.functional.dynamic-store-off.yml
+++ b/deploy.ci.functional.dynamic-store-off.yml
@@ -118,7 +118,7 @@ services:
             password: "secret"
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: "spryker"
             password: "secret"

--- a/deploy.ci.functional.mariadb.dynamic-store-off.yml
+++ b/deploy.ci.functional.mariadb.dynamic-store-off.yml
@@ -119,7 +119,7 @@ services:
             password: "secret"
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: "spryker"
             password: "secret"

--- a/deploy.ci.functional.mariadb.prefer-lowest.yml
+++ b/deploy.ci.functional.mariadb.prefer-lowest.yml
@@ -102,7 +102,7 @@ services:
             password: 'secret'
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: 'spryker'
             password: 'secret'

--- a/deploy.ci.functional.mariadb.yml
+++ b/deploy.ci.functional.mariadb.yml
@@ -96,7 +96,7 @@ services:
             password: 'secret'
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: 'spryker'
             password: 'secret'

--- a/deploy.ci.functional.yml
+++ b/deploy.ci.functional.yml
@@ -92,7 +92,7 @@ services:
             password: 'secret'
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: 'spryker'
             password: 'secret'

--- a/deploy.dev.dynamic-store-off.yml
+++ b/deploy.dev.dynamic-store-off.yml
@@ -219,7 +219,7 @@ services:
                 protocol: tcp
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: "spryker"
             password: "secret"

--- a/deploy.dev.yml
+++ b/deploy.dev.yml
@@ -190,7 +190,7 @@ services:
                 protocol: tcp
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: 'spryker'
             password: 'secret'

--- a/deploy.dynamic-store-off.yml
+++ b/deploy.dynamic-store-off.yml
@@ -203,7 +203,7 @@ services:
                 protocol: tcp
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: "spryker"
             password: "secret"

--- a/deploy.spryker-dynamicstore.yml
+++ b/deploy.spryker-dynamicstore.yml
@@ -159,7 +159,7 @@ services:
                 protocol: tcp
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: 'spryker'
             password: 'secret'

--- a/deploy.yml
+++ b/deploy.yml
@@ -197,7 +197,7 @@ services:
                 protocol: tcp
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: 'spryker'
             password: 'secret'


### PR DESCRIPTION
#### Overview

- Ticket: https://spryker.atlassian.net/browse/OPS-4941

###### Change log

- Updated RabbitMQ service version from 3.9 to 3.13 across all deployment configurations to ensure environment consistency and prevent version-related compatibility issues.
