### PR TITLE
FRW-10660 Integration

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -34520,16 +34520,16 @@
         },
         {
             "name": "spryker/product",
-            "version": "6.49.0",
+            "version": "6.50.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/product.git",
-                "reference": "fe152abd8526fa65b7a7022370547a0f9fce8155"
+                "reference": "fd78bfba8d5a52bb2081b14009418430d6ddd1b8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/product/zipball/fe152abd8526fa65b7a7022370547a0f9fce8155",
-                "reference": "fe152abd8526fa65b7a7022370547a0f9fce8155",
+                "url": "https://api.github.com/repos/spryker/product/zipball/fd78bfba8d5a52bb2081b14009418430d6ddd1b8",
+                "reference": "fd78bfba8d5a52bb2081b14009418430d6ddd1b8",
                 "shasum": ""
             },
             "require": {
@@ -34580,9 +34580,9 @@
             ],
             "description": "Product module",
             "support": {
-                "source": "https://github.com/spryker/product/tree/6.49.0"
+                "source": "https://github.com/spryker/product/tree/6.50.0"
             },
-            "time": "2025-04-18T12:00:41+00:00"
+            "time": "2025-08-04T11:20:12+00:00"
         },
         {
             "name": "spryker/product-abstract-data-feed",
@@ -35337,16 +35337,16 @@
         },
         {
             "name": "spryker/product-bundle",
-            "version": "7.24.0",
+            "version": "7.26.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/product-bundle.git",
-                "reference": "84bf5b270c679df6fb45dba166375b16ca29b8ac"
+                "reference": "45831d48b089b076b42e048516e8c571d21d70b7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/product-bundle/zipball/84bf5b270c679df6fb45dba166375b16ca29b8ac",
-                "reference": "84bf5b270c679df6fb45dba166375b16ca29b8ac",
+                "url": "https://api.github.com/repos/spryker/product-bundle/zipball/45831d48b089b076b42e048516e8c571d21d70b7",
+                "reference": "45831d48b089b076b42e048516e8c571d21d70b7",
                 "shasum": ""
             },
             "require": {
@@ -35414,9 +35414,9 @@
             ],
             "description": "ProductBundle module",
             "support": {
-                "source": "https://github.com/spryker/product-bundle/tree/7.24.0"
+                "source": "https://github.com/spryker/product-bundle/tree/7.26.0"
             },
-            "time": "2025-07-03T14:22:10+00:00"
+            "time": "2025-08-04T11:20:12+00:00"
         },
         {
             "name": "spryker/product-bundle-carts-rest-api",
@@ -41144,16 +41144,16 @@
         },
         {
             "name": "spryker/propel-orm",
-            "version": "1.21.0",
+            "version": "1.21.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/propel-orm.git",
-                "reference": "e3afb4b9719fd5ba72592846c10ac5c4e636effb"
+                "reference": "575951b8a1b887c60d2ec593ba89d0498d13be9f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/propel-orm/zipball/e3afb4b9719fd5ba72592846c10ac5c4e636effb",
-                "reference": "e3afb4b9719fd5ba72592846c10ac5c4e636effb",
+                "url": "https://api.github.com/repos/spryker/propel-orm/zipball/575951b8a1b887c60d2ec593ba89d0498d13be9f",
+                "reference": "575951b8a1b887c60d2ec593ba89d0498d13be9f",
                 "shasum": ""
             },
             "require": {
@@ -41189,9 +41189,9 @@
             ],
             "description": "PropelOrm module",
             "support": {
-                "source": "https://github.com/spryker/propel-orm/tree/1.21.0"
+                "source": "https://github.com/spryker/propel-orm/tree/1.21.2"
             },
-            "time": "2024-09-20T14:38:30+00:00"
+            "time": "2025-07-25T07:53:52+00:00"
         },
         {
             "name": "spryker/propel-orm-extension",


### PR DESCRIPTION
#### Overview

- Ticket: https://spryker.atlassian.net/browse/FRW-10660

###### Change log

Integration.

###### CI Notice
Tests do **not** run automatically on every PR.
To trigger the required test suites, please add the appropriate label(s) to your PR.
For the full list of labels and their associated tests, see our Confluence page: [CI Test Labels & Triggers](https://spryker.atlassian.net/wiki/spaces/Framework/pages/4715216905/Using+PR+labels+to+control+CI+runs+for+project+repositories)
