### PR TITLE
Update guzzlehttp/guzzle to 7.15.2

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1569,16 +1569,16 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.15.1",
+            "version": "7.15.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "61443dfb33c62f308ee8add20f45b4d6e4bf8d2f"
+                "reference": "744101956d78b7c1384d0cbf379db13e859167bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/61443dfb33c62f308ee8add20f45b4d6e4bf8d2f",
-                "reference": "61443dfb33c62f308ee8add20f45b4d6e4bf8d2f",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/744101956d78b7c1384d0cbf379db13e859167bf",
+                "reference": "744101956d78b7c1384d0cbf379db13e859167bf",
                 "shasum": ""
             },
             "require": {
@@ -1677,7 +1677,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.15.1"
+                "source": "https://github.com/guzzle/guzzle/tree/7.15.2"
             },
             "funding": [
                 {
@@ -1693,7 +1693,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-18T11:23:11+00:00"
+            "time": "2026-07-26T23:23:20+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -67142,7 +67142,7 @@
         "ext-readline": "*",
         "ext-redis": "*"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "8.3.13"
     },


### PR DESCRIPTION
#### Overview

Lock-only bump of `guzzlehttp/guzzle` 7.15.1 → 7.15.2. No ticket — this clears the `OPEN SOURCE VULNERABILITIES CHECKER` red in the `Static analysis` job.

- [GHSA-v5mv-p594-2x33](https://github.com/advisories/GHSA-v5mv-p594-2x33) (CVE-2026-69246, HIGH) — noncanonical host can bypass host-based checks
- [GHSA-f7vp-7xgx-4w4r](https://github.com/advisories/GHSA-f7vp-7xgx-4w4r) (CVE-2026-69245, MODERATE) — noncanonical cookie domain keeps subdomain scope

Both advisories were published 2026-08-03 and are fixed in 7.15.2. Guzzle is transitive only; the tightest constraint in the tree is `spryker/guzzle ^7.5.1`, so no `composer.json` change is needed.

###### Test plan

- `Static analysis (8.3)` / `(8.4)` must go green — specifically `Run Evaluator for all branches`, which currently exits 1 on this checker.
- `composer audit` reports no advisories on the updated lock.
- Everything else is regression surface only: patch release of a transitive HTTP client, no first-party code touched.
