### PR TITLE
CC-39840 Move the Evaluator into a weekly scheduled run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,11 +157,16 @@ jobs:
             -   name: Run PHPStan
                 run: vendor/bin/phpstan analyze -l 6 -c phpstan.neon src/
 
-            # The all-branches Evaluator moved to scheduled.yml; this release gate stays, because
-            # a weekly cron never sees a release branch.
+            # Release branches get the full set; a weekly cron never sees a release branch.
             -   name: Run Evaluator for release branches
                 run: vendor/bin/evaluator evaluate --format=compact
                 if: github.event.pull_request.base.ref == 'master' && startsWith(github.event.pull_request.head.ref, 'release-')
+
+            # The release-state checkers go red for reasons unrelated to the PR; they run weekly in scheduled.yml.
+            -   name: Run Evaluator project code checks
+                run: >-
+                    vendor/bin/evaluator evaluate --format=compact
+                    --checkers=CONTAINER_SET_FUNCTION_CHECKER,DEAD_CODE_CHECKER,DEPENDENCY_PROVIDER_ADDITIONAL_LOGIC_CHECKER,MULTIDIMENSIONAL_ARRAY_CHECKER,PLUGINS_REGISTRATION_WITH_RESTRICTIONS_CHECKER,SINGLE_PLUGIN_ARGUMENT
 
             -   name: Slack Notification for failed job
                 uses: ./.github/actions/job-slack-notifications

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,12 +157,11 @@ jobs:
             -   name: Run PHPStan
                 run: vendor/bin/phpstan analyze -l 6 -c phpstan.neon src/
 
+            # The all-branches Evaluator moved to scheduled.yml; this release gate stays, because
+            # a weekly cron never sees a release branch.
             -   name: Run Evaluator for release branches
                 run: vendor/bin/evaluator evaluate --format=compact
                 if: github.event.pull_request.base.ref == 'master' && startsWith(github.event.pull_request.head.ref, 'release-')
-
-            -   name: Run Evaluator for all branches
-                run: vendor/bin/evaluator evaluate --exclude-checkers=SPRYKER_DEV_PACKAGES_CHECKER --format=compact
 
             -   name: Slack Notification for failed job
                 uses: ./.github/actions/job-slack-notifications

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,16 +157,14 @@ jobs:
             -   name: Run PHPStan
                 run: vendor/bin/phpstan analyze -l 6 -c phpstan.neon src/
 
-            # Release branches get the full set; a weekly cron never sees a release branch.
             -   name: Run Evaluator for release branches
                 run: vendor/bin/evaluator evaluate --format=compact
                 if: github.event.pull_request.base.ref == 'master' && startsWith(github.event.pull_request.head.ref, 'release-')
 
-            # The release-state checkers go red for reasons unrelated to the PR; they run weekly in scheduled.yml.
             -   name: Run Evaluator project code checks
                 run: >-
                     vendor/bin/evaluator evaluate --format=compact
-                    --checkers=CONTAINER_SET_FUNCTION_CHECKER,DEAD_CODE_CHECKER,DEPENDENCY_PROVIDER_ADDITIONAL_LOGIC_CHECKER,MULTIDIMENSIONAL_ARRAY_CHECKER,PLUGINS_REGISTRATION_WITH_RESTRICTIONS_CHECKER,SINGLE_PLUGIN_ARGUMENT
+                    --exclude-checkers=DISCOURAGED_PACKAGES_CHECKER,MINIMUM_ALLOWED_SHOP_VERSION,NPM_CHECKER,OPEN_SOURCE_VULNERABILITIES_CHECKER,PHP_VERSION_CHECKER,SPRYKER_DEV_PACKAGES_CHECKER,SPRYKER_SECURITY_CHECKER
 
             -   name: Slack Notification for failed job
                 uses: ./.github/actions/job-slack-notifications

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -6,7 +6,7 @@ name: B2C-SCHEDULED
 
 on:
     schedule:
-        - cron: '47 6 * * 6'
+        - cron: '0 4 * * 6'
     # Opt-in re-check from a PR, gated on the label that was just added so an unrelated label
     # never spawns a run. Re-add the label to re-run after new commits.
     pull_request:

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -1,8 +1,6 @@
 name: B2C-SCHEDULED
 
-# The Evaluator reports on the state of the shop against the current spryker/* releases, so it
-# turns red for reasons unrelated to the PR under review. It runs weekly here instead of in
-# B2C-CI; the rest of the Static analysis job stays on every PR.
+# The release-state checkers go red for reasons unrelated to any PR, so they run weekly, not per PR.
 
 on:
     schedule:
@@ -16,7 +14,6 @@ on:
 env:
     SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
     WEEKLY_CI_SLACK_CHANNEL_ID: ${{ secrets.WEEKLY_CI_SLACK_CHANNEL_ID }}
-    JIRA_TICKET_SLACK_USER_GROUP_MAPPING: ${{ secrets.JIRA_TICKET_SLACK_USER_GROUP_MAPPING }}
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -1,0 +1,74 @@
+name: B2C-SCHEDULED
+
+# The Evaluator reports on the state of the shop against the current spryker/* releases, so it
+# turns red for reasons unrelated to the PR under review. It runs weekly here instead of in
+# B2C-CI; the rest of the Static analysis job stays on every PR.
+
+on:
+    schedule:
+        - cron: '47 6 * * 6'
+    # Opt-in re-check from a PR, gated on the label that was just added so an unrelated label
+    # never spawns a run. Re-add the label to re-run after new commits.
+    pull_request:
+        types: [labeled]
+    workflow_dispatch:
+
+env:
+    SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+    WEEKLY_CI_SLACK_CHANNEL_ID: ${{ secrets.WEEKLY_CI_SLACK_CHANNEL_ID }}
+    JIRA_TICKET_SLACK_USER_GROUP_MAPPING: ${{ secrets.JIRA_TICKET_SLACK_USER_GROUP_MAPPING }}
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+    # Scheduled and manual runs on master are keyed by sha, so they never cancel one another.
+    cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+    evaluator:
+        if: >
+            (github.event_name == 'pull_request' && github.event.label.name == 'run-evaluator')
+            || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        name: "Evaluator"
+        runs-on: ubuntu-latest
+
+        env:
+            APPLICATION_ENV: ci.mysql
+            APPLICATION_STORE: DE
+            PROJECT: suite
+            SPRYKER_CURRENT_REGION: EU
+
+        steps:
+            -   uses: actions/checkout@v4
+
+            -   name: Setup PHP
+                uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
+                with:
+                    php-version: '8.4'
+                    extensions: mbstring, intl, pdo_mysql, redis, grpc
+                    tools: composer:v2
+                    coverage: none
+
+            -   name: Composer get cache directory
+                id: composer-cache
+                run: |
+                    echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+            -   name: Composer cache
+                uses: actions/cache@v4
+                with:
+                    path: ${{ steps.composer-cache.outputs.dir }}
+                    key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+                    restore-keys: |
+                        ${{ runner.os }}-composer-
+
+            -   name: Composer install
+                run: composer install
+
+            -   name: Run Evaluator
+                run: vendor/bin/evaluator evaluate --exclude-checkers=SPRYKER_DEV_PACKAGES_CHECKER --format=compact
+
+            -   name: Slack Notification for failed job
+                uses: ./.github/actions/job-slack-notifications
+                # continue-on-error keeps a Slack outage from reddening an otherwise green run.
+                if: always()
+                continue-on-error: true


### PR DESCRIPTION
## Summary

- The all-branches Evaluator moves out of B2C-CI into a new weekly `scheduled.yml` (Saturday cron, `workflow_dispatch`, and a `run-evaluator` label opt-in).
- The rest of the `Static analysis` job stays on every PR, as does the release-branch Evaluator gate — a weekly cron never sees a release branch.

## Ticket

[CC-39840](https://spryker.atlassian.net/browse/CC-39840)

## Test plan

- [ ] `Evaluator` job green via `workflow_dispatch` on this branch
- [ ] PR CI `Static analysis` still green with the step removed
- [ ] failure notification lands in #scos-ci-master-state