### PR TITLE
CC-39284 Build-once DB restore and sharded E2E matrices

### DIFF
--- a/.github/actions/validate-sync-completeness/action.yml
+++ b/.github/actions/validate-sync-completeness/action.yml
@@ -1,0 +1,45 @@
+name: 'Validate sync completeness'
+description: 'Checks product sync counts DB vs ES vs Redis; fails if mismatched or sync queues non-empty'
+
+runs:
+    using: "composite"
+    steps:
+        -   name: Validate sync completeness
+            shell: bash
+            run: |
+                docker/sdk cli '
+                    set +e
+                    SYNC_FAIL=0
+                    curl -sf "http://$SPRYKER_SEARCH_HOST:$SPRYKER_SEARCH_PORT/_refresh" > /dev/null || true
+
+                    echo "=== ES/OS indices ==="
+                    curl -s "http://$SPRYKER_SEARCH_HOST:$SPRYKER_SEARCH_PORT/_cat/indices?h=index,docs.count&s=docs.count:desc" | head -20 || true
+
+                    echo ""
+                    echo "=== Product data sync completeness ==="
+                    DB_ABSTRACT=$(mariadb --ssl=false -h "$SPRYKER_DB_HOST" -u "$SPRYKER_DB_USERNAME" -p"$SPRYKER_DB_PASSWORD" "$SPRYKER_DB_DATABASE" -sNe "SELECT COUNT(*) FROM spy_product_abstract_page_search" 2>/dev/null) || DB_ABSTRACT=0
+                    DB_CONCRETE=$(mariadb --ssl=false -h "$SPRYKER_DB_HOST" -u "$SPRYKER_DB_USERNAME" -p"$SPRYKER_DB_PASSWORD" "$SPRYKER_DB_DATABASE" -sNe "SELECT COUNT(*) FROM spy_product_concrete_storage" 2>/dev/null) || DB_CONCRETE=0
+                    ES_ABSTRACT=$(curl -sf "http://$SPRYKER_SEARCH_HOST:$SPRYKER_SEARCH_PORT/*_page/_count?q=type:product_abstract" 2>/dev/null | python3 -c "import sys,json;print(json.load(sys.stdin)[\"count\"])" 2>/dev/null) || ES_ABSTRACT=0
+                    REDIS_CONCRETE=$(redis-cli -h "$SPRYKER_KEY_VALUE_STORE_HOST" -p "$SPRYKER_KEY_VALUE_STORE_PORT" -n 1 --scan --count 10000 2>/dev/null | grep "^kv:product_concrete:" | grep -cv ":sku:") || REDIS_CONCRETE=0
+
+                    check_row() {
+                        local label="$1" expected="$2" actual="$3" status="OK"
+                        [ "$expected" != "$actual" ] && { status="FAIL"; SYNC_FAIL=1; }
+                        printf "  %-63s %8s %8s  %s\n" "$label" "$expected" "$actual" "$status"
+                    }
+                    printf "  %-63s %8s %8s  %s\n" "Check" "Expected" "Actual" "Status"
+                    python3 -c "print(\"  \" + \"-\" * 88)"
+                    check_row "spy_product_abstract_page_search -> ES *_page (product_abstract)" "$DB_ABSTRACT" "$ES_ABSTRACT"
+                    check_row "spy_product_concrete_storage -> Redis kv:product_concrete:*" "$DB_CONCRETE" "$REDIS_CONCRETE"
+
+                    echo ""
+                    echo "  spy_product_abstract_page_search by store/locale:"
+                    mariadb --ssl=false -h "$SPRYKER_DB_HOST" -u "$SPRYKER_DB_USERNAME" -p"$SPRYKER_DB_PASSWORD" "$SPRYKER_DB_DATABASE" \
+                        -e "SELECT store, locale, COUNT(*) AS row_count FROM spy_product_abstract_page_search GROUP BY store, locale ORDER BY store, locale" 2>/dev/null | sed "s/^/  /" || true
+
+                    echo ""
+                    echo "=== Sync queue states ==="
+                    curl -sf -u "$SPRYKER_BROKER_API_USERNAME:$SPRYKER_BROKER_API_PASSWORD" "http://$SPRYKER_BROKER_API_HOST:$SPRYKER_BROKER_API_PORT/api/queues" | python3 -c "import sys,json;qs=json.load(sys.stdin);non=sorted([(q[\"name\"],q.get(\"messages\",0),q.get(\"messages_ready\",0),q.get(\"messages_unacknowledged\",0)) for q in qs if q[\"name\"].startswith(\"sync.\") and q.get(\"messages\",0)>0]);[print(n+\": total=\"+str(t)+\" ready=\"+str(r)+\" unacked=\"+str(u)) for n,t,r,u in non] or print(\"all sync.* queues empty\")" || true
+
+                    [ "$SYNC_FAIL" -ne 0 ] && { echo ""; echo "ERROR: sync completeness check FAILED"; exit 1; } || true
+                '

--- a/.github/workflows/_build-db.yml
+++ b/.github/workflows/_build-db.yml
@@ -1,0 +1,85 @@
+name: _build-db
+
+# Build-once EU dump.
+#
+# Boots the existing acceptance pipeline and runs `docker/sdk up -t`, so full_EU is
+# imported byte-identically to a normal acceptance boot. Then snapshots the DB to
+# eu-docker.sql and publishes it as the `spryker-app-db` artifact, which every
+# consumer restores via SPRYKER_PIPELINE=ci.restore-db.stage2. One dump serves all
+# consumers here — Robot imports the same full_EU as Codeception and Cypress.
+
+on:
+    workflow_call:
+
+env:
+    SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+    WEEKLY_CI_SLACK_CHANNEL_ID: ${{ secrets.WEEKLY_CI_SLACK_CHANNEL_ID }}
+    JIRA_TICKET_SLACK_USER_GROUP_MAPPING: ${{ secrets.JIRA_TICKET_SLACK_USER_GROUP_MAPPING }}
+
+jobs:
+    build-db:
+        name: "Build DB (EU)"
+        timeout-minutes: 60
+        runs-on: ubuntu-latest
+        env:
+            PROGRESS_TYPE: plain
+            SPRYKER_PLATFORM_IMAGE: spryker/php:8.4
+            TRAVIS: 1
+            SPRYKER_CURRENT_REGION: EU
+            DYNAMIC_STORE_MODE: true
+        steps:
+            -   uses: actions/checkout@v4
+
+            -   uses: ramsey/composer-install@v3
+                with:
+                    composer-options: "-q --ignore-platform-reqs --optimize-autoloader --no-interaction --prefer-install=auto"
+
+            -   name: Configure sysctl limits
+                run: |
+                    sudo sysctl -w vm.swappiness=10
+                    sudo sysctl -w fs.file-max=262144
+                    sudo sysctl -w vm.max_map_count=262144
+                    ulimit -n 65536
+
+            -   name: Run project in Docker
+                run: |
+                    git clone https://github.com/spryker/docker-sdk.git ./docker && git -C ./docker fetch --depth 1 origin $(cat .git.docker) && git -C ./docker checkout $(cat .git.docker)
+                    docker/sdk boot deploy.ci.acceptance.mariadb.yml
+
+            -   uses: ./.github/actions/setup-etc-hosts
+
+            -   name: Install project
+                run: |
+                    docker/sdk up -t
+                    docker/sdk cli composer dump-autoload -o -a --apcu -q
+
+            -   name: Dump details
+                run: |
+                    query() { docker/sdk cli "mariadb --ssl=false -h \$SPRYKER_DB_HOST -u \$SPRYKER_DB_USERNAME -p\$SPRYKER_DB_PASSWORD \$SPRYKER_DB_DATABASE -sNe '$1'"; }
+                    echo "spy_product_abstract:                          $(query 'SELECT COUNT(*) FROM spy_product_abstract')"
+                    echo "spy_product:                                   $(query 'SELECT COUNT(*) FROM spy_product')"
+                    echo "spy_product_abstract_page_search (total keys): $(query 'SELECT COUNT(*) FROM spy_product_abstract_page_search')"
+                    echo "spy_product_concrete_storage (total keys):     $(query 'SELECT COUNT(*) FROM spy_product_concrete_storage')"
+
+            -   name: Create database dump
+                # Two-step dump: schema (--no-data) then data (--no-create-info), excluding the
+                # oauth/token-cache tables that the restore re-initialises via setup:init-db.
+                # `\$` keeps the expansion inside the container.
+                run: |
+                    docker/sdk cli "mariadb-dump --ssl=false -h \$SPRYKER_DB_HOST -u \$SPRYKER_DB_USERNAME -p\$SPRYKER_DB_PASSWORD \$SPRYKER_DB_DATABASE --no-data" > eu-docker.sql
+                    docker/sdk cli "mariadb-dump --ssl=false -h \$SPRYKER_DB_HOST -u \$SPRYKER_DB_USERNAME -p\$SPRYKER_DB_PASSWORD \$SPRYKER_DB_DATABASE --no-create-info --ignore-table=\$SPRYKER_DB_DATABASE.spy_oauth_client --ignore-table=\$SPRYKER_DB_DATABASE.spy_unauthenticated_customer_access --ignore-table=\$SPRYKER_DB_DATABASE.spy_oauth_client_access_token_cache" >> eu-docker.sql
+                    echo "eu-docker.sql size: $(wc -c < eu-docker.sql) bytes"
+
+            -   name: Save project artifacts
+                uses: actions/upload-artifact@v6
+                with:
+                    name: spryker-app-db
+                    retention-days: 1
+                    overwrite: true
+                    path: |
+                        eu-docker.sql
+                    compression-level: 6 # 0: No compression, 1: Best speed, 6: Default compression (same as GNU Gzip), 9: Best compression
+
+            -   name: Slack Notification for failed job
+                uses: ./.github/actions/job-slack-notifications
+                if: always()

--- a/.github/workflows/_build-db.yml
+++ b/.github/workflows/_build-db.yml
@@ -30,10 +30,6 @@ jobs:
         steps:
             -   uses: actions/checkout@v4
 
-            -   uses: ramsey/composer-install@v3
-                with:
-                    composer-options: "-q --ignore-platform-reqs --optimize-autoloader --no-interaction --prefer-install=auto"
-
             -   name: Configure sysctl limits
                 run: |
                     sudo sysctl -w vm.swappiness=10
@@ -41,17 +37,17 @@ jobs:
                     sudo sysctl -w vm.max_map_count=262144
                     ulimit -n 65536
 
-            -   name: Run project in Docker
+            -   name: Boot Project
                 run: |
-                    git clone https://github.com/spryker/docker-sdk.git ./docker && git -C ./docker fetch --depth 1 origin $(cat .git.docker) && git -C ./docker checkout $(cat .git.docker)
+                    git clone --depth 1 https://github.com/spryker/docker-sdk.git ./docker
                     docker/sdk boot deploy.ci.acceptance.mariadb.yml
 
             -   uses: ./.github/actions/setup-etc-hosts
 
-            -   name: Install project
+            -   name: Install Project
                 run: |
                     docker/sdk up -t
-                    docker/sdk cli composer dump-autoload -o -a --apcu -q
+                    docker/sdk cli composer dump-autoload -o -a --apcu
 
             -   name: Dump details
                 run: |

--- a/.github/workflows/_codeception.yml
+++ b/.github/workflows/_codeception.yml
@@ -24,12 +24,31 @@ jobs:
         steps:
             -   uses: actions/checkout@v4
 
-            -   name: Run docker
+            # Must land before the boot so the dump is part of the baked image.
+            -   uses: actions/download-artifact@v6
+                with:
+                    name: spryker-app-db
+
+            -   name: Boot Project
                 run: |
                     git clone --depth 1 https://github.com/spryker/docker-sdk.git ./docker
                     docker/sdk boot deploy.ci.acceptance.mariadb.yml
+
+            -   name: Install Project
+                # Build-once: restore the shared full_EU dump via ci.restore-db.stage2 instead
+                # of importing demodata here. The deploy file's own pipeline key is untouched;
+                # only SPRYKER_PIPELINE is overridden for this invocation.
+                env:
+                    SPRYKER_PIPELINE: ci.restore-db.stage2
+                run: |
                     docker/sdk up -t
                     docker/sdk cli composer dump-autoload -o -a --apcu
+
+            -   name: Validate sync completeness
+                uses: ./.github/actions/validate-sync-completeness
+
+            -   name: Run Fixtures
+                run: |
                     docker/sdk testing codecept fixtures
                     docker/sdk testing console queue:worker:start --stop-when-empty
 
@@ -58,12 +77,28 @@ jobs:
         steps:
             -   uses: actions/checkout@v4
 
-            -   name: Run docker
+            # Must land before the boot so the dump is part of the baked image.
+            -   uses: actions/download-artifact@v6
+                with:
+                    name: spryker-app-db
+
+            -   name: Boot Project
                 run: |
                     git clone --depth 1 https://github.com/spryker/docker-sdk.git ./docker
                     docker/sdk boot deploy.ci.functional.mariadb.yml
+
+            -   name: Install Project
+                env:
+                    SPRYKER_PIPELINE: ci.restore-db.stage2
+                run: |
                     docker/sdk up -t
                     docker/sdk cli composer dump-autoload -o -a --apcu
+
+            -   name: Validate sync completeness
+                uses: ./.github/actions/validate-sync-completeness
+
+            -   name: Run Tests
+                run: |
                     docker/sdk testing codecept run -c codeception.functional.yml
 
             -   name: Slack Notification for failed job

--- a/.github/workflows/_cypress.yml
+++ b/.github/workflows/_cypress.yml
@@ -12,22 +12,44 @@ env:
     ROBOT_TESTS_ARTIFACTS_BUCKET_REGION: eu-west-1
 
 jobs:
+    cypress-shards:
+        name: "Cypress shard manifest"
+        timeout-minutes: 10
+        runs-on: ubuntu-latest
+        outputs:
+            shards: ${{ steps.compute.outputs.shards }}
+        steps:
+            -   uses: actions/checkout@v4
+
+            # Same install trick the test job uses, into the scratch ./data dir: the
+            # installed package is the single source of truth for which specs exist, so the
+            # matrix is generated from the same tree the shards will run.
+            -   name: Install cypress-tests folder
+                run: |
+                    cd ./data && composer require "spryker/cypress-tests:dev-release_202512.0_state" --dev --no-interaction
+
+            -   id: compute
+                name: Generate shard matrix
+                # No timings file exists for the pinned branch yet, so the generator packs by
+                # spec count and logs a ::notice::. Its self-check fails the job red if the
+                # packed spec set is not exactly the installed spec set, which is what keeps
+                # the executed-test set identical to the unsharded baseline.
+                run: |
+                    SHARDS=$(.github/workflows/scripts/generate-cypress-shards.py \
+                        --package-dir data/vendor/spryker/cypress-tests \
+                        --shards 5)
+                    echo "shards=${SHARDS}" >> "$GITHUB_OUTPUT"
+                    echo "Computed Cypress shards: ${SHARDS}"
+
     cypress:
         name: "Cypress / UI ${{ matrix.shard.label }}"
         timeout-minutes: 75
+        needs: cypress-shards
         runs-on: ubuntu-latest
         strategy:
             fail-fast: false
-            # Matrix of one: the whole spec set in a single job, i.e. exactly what the
-            # monolithic job used to do. The shard shape is already here so that turning
-            # sharding on is a change of this list plus one extra run step.
             matrix:
-                shard:
-                    -   label: "1/1"
-                        shard: "1"
-                        total: 1
-                        specs: ""
-                        mode: "all"
+                shard: ${{ fromJson(needs.cypress-shards.outputs.shards) }}
         env:
             PROGRESS_TYPE: plain
             SPRYKER_PLATFORM_IMAGE: spryker/php:8.4
@@ -37,6 +59,11 @@ jobs:
             DYNAMIC_STORE_MODE: true
         steps:
             -   uses: actions/checkout@v4
+
+            # Must land before the boot so the dump is in place for the restore pipeline.
+            -   uses: actions/download-artifact@v6
+                with:
+                    name: spryker-app-db
 
             -   name: Install packages
                 run: |
@@ -50,6 +77,14 @@ jobs:
                     cd ./data && composer require "spryker/cypress-tests:dev-release_202512.0_state" --dev --no-interaction
                     cp -r vendor/spryker/cypress-tests ../tests/cypress-tests
 
+            -   name: Set core spec list
+                env:
+                    SPECS: ${{ matrix.shard.specs }}
+                run: |
+                    n=$(awk -F, '{print NF}' <<<"$SPECS")
+                    echo "CORE_SPECS=${SPECS}" >> "$GITHUB_ENV"
+                    echo "Shard ${{ matrix.shard.label }}: ${n} spec(s)"
+
             -   name: Boot Project
                 run: |
                     git clone --depth 1 https://github.com/spryker/docker-sdk.git ./docker
@@ -59,20 +94,29 @@ jobs:
             -   uses: ./.github/actions/setup-etc-hosts
 
             -   name: Install Project
+                # Build-once: restore the shared full_EU dump via ci.restore-db.stage2 instead
+                # of importing demodata per shard. The deploy file's own pipeline key is
+                # untouched; only SPRYKER_PIPELINE is overridden for this invocation.
+                env:
+                    SPRYKER_PIPELINE: ci.restore-db.stage2
                 run: |
                     docker/sdk up -t
                     docker/sdk cli composer dump-autoload -o -a --apcu
 
+            -   name: Validate sync completeness
+                uses: ./.github/actions/validate-sync-completeness
+
             -   name: Run Tests
-                if: matrix.shard.mode == 'all'
+                if: matrix.shard.mode == 'core' && env.CORE_SPECS != ''
                 run: |
                     docker/sdk exec cypress-tests cp .env.dynamic-store.example .env
-                    docker/sdk exec --env "ENV_REPOSITORY_ID=b2c" cypress-tests npm run cy:ci
+                    docker/sdk exec --env "ENV_REPOSITORY_ID=b2c" cypress-tests \
+                        npx cypress run --headless --browser chrome --spec "$CORE_SPECS"
 
             -   name: Upload artifacts
                 if: failure()
                 run: |
-                    AWS_DEFAULT_REGION=${{env.ROBOT_TESTS_ARTIFACTS_BUCKET_REGION}} AWS_ACCESS_KEY_ID=${{ secrets.ROBOT_TESTS_ARTIFACTS_KEY }} AWS_SECRET_ACCESS_KEY=${{ secrets.ROBOT_TESTS_ARTIFACTS_SECRET }} aws s3 cp .cypress s3://${{vars.ROBOT_TESTS_ARTIFACTS_BUCKET}}/b2c/dms-on/cypress/${GITHUB_RUN_ID}/PHP8.4MariaDB/ --recursive
+                    AWS_DEFAULT_REGION=${{env.ROBOT_TESTS_ARTIFACTS_BUCKET_REGION}} AWS_ACCESS_KEY_ID=${{ secrets.ROBOT_TESTS_ARTIFACTS_KEY }} AWS_SECRET_ACCESS_KEY=${{ secrets.ROBOT_TESTS_ARTIFACTS_SECRET }} aws s3 cp .cypress s3://${{vars.ROBOT_TESTS_ARTIFACTS_BUCKET}}/b2c/dms-on/cypress/${GITHUB_RUN_ID}/PHP8.4MariaDB/shard-${{ matrix.shard.shard }}/ --recursive
 
             -   name: Slack Notification for failed job
                 uses: ./.github/actions/job-slack-notifications

--- a/.github/workflows/_robot-api.yml
+++ b/.github/workflows/_robot-api.yml
@@ -11,10 +11,39 @@ env:
     JIRA_TICKET_SLACK_USER_GROUP_MAPPING: ${{ secrets.JIRA_TICKET_SLACK_USER_GROUP_MAPPING }}
 
 jobs:
-    robot-api:
-        name: "Robot / API"
-        timeout-minutes: 60
+    # Pure matrix-compute job (bash only) — emits ROBOT_SHARD_COUNT shards as
+    # {label,shard,total} JSON. The per-shard file slice is computed in the test job,
+    # where the installed suite tree is available to walk.
+    robot-api-shards:
+        name: "Robot API shards"
+        timeout-minutes: 2
         runs-on: ubuntu-latest
+        outputs:
+            shards: ${{ steps.compute.outputs.shards }}
+        steps:
+            -   id: compute
+                env:
+                    ROBOT_SHARD_COUNT: "2"
+                run: |
+                    n="${ROBOT_SHARD_COUNT}"
+                    SHARDS="["
+                    for i in $(seq 1 "$n"); do
+                        [ "$i" -gt 1 ] && SHARDS="${SHARDS},"
+                        SHARDS="${SHARDS}{\"label\":\"${i}/${n}\",\"shard\":${i},\"total\":${n}}"
+                    done
+                    SHARDS="${SHARDS}]"
+                    echo "shards=${SHARDS}" >> "$GITHUB_OUTPUT"
+                    echo "Computed Robot API shards: ${SHARDS}"
+
+    robot-api:
+        name: "Robot / API ${{ matrix.shard.label }}"
+        timeout-minutes: 60
+        needs: robot-api-shards
+        runs-on: ubuntu-latest
+        strategy:
+            fail-fast: false
+            matrix:
+                shard: ${{ fromJson(needs.robot-api-shards.outputs.shards) }}
         env:
             PROGRESS_TYPE: plain
             SPRYKER_PLATFORM_IMAGE: spryker/php:8.4
@@ -22,8 +51,14 @@ jobs:
             ROBOT_TESTS_ARTIFACTS_BUCKET_REGION: eu-west-1
             SPRYKER_CURRENT_REGION: EU
             DYNAMIC_STORE_MODE: true
+            TEST_SET: api/b2c
         steps:
             -   uses: actions/checkout@v4
+
+            # Must land before the boot so the dump is part of the baked image.
+            -   uses: actions/download-artifact@v6
+                with:
+                    name: spryker-app-db
 
             -   name: Install packages
                 run: |
@@ -37,6 +72,34 @@ jobs:
                     cd ./data && composer require "spryker/robotframework-suite-tests:dev-release_202512.0_state" --dev --no-interaction
                     cp -r vendor ../vendor
 
+            -   name: Compute shard slice
+                env:
+                    SHARD: ${{ matrix.shard.shard }}
+                    TOTAL: ${{ matrix.shard.total }}
+                run: |
+                    # Suite files live directly under tests/<set>/** (no /suite/ subdir). Strip
+                    # the vendor package prefix so the paths resolve inside the robot-framework
+                    # container, whose cwd is the mounted package root (/opt/robotframework).
+                    mapfile -t suites < <(find vendor -type f -path "*/tests/${TEST_SET}/*.robot" \
+                        | LC_ALL=C sort \
+                        | sed 's|^vendor/spryker/robotframework-suite-tests/||')
+
+                    # Remainder-distribution slice: the first (n % TOTAL) shards take one extra
+                    # file, so every file lands in exactly one shard.
+                    n=${#suites[@]}
+                    base=$(( n / TOTAL ))
+                    extra=$(( n % TOTAL ))
+                    if (( SHARD - 1 < extra )); then
+                        start=$(( (SHARD - 1) * (base + 1) ))
+                        size=$(( base + 1 ))
+                    else
+                        start=$(( extra * (base + 1) + (SHARD - 1 - extra) * base ))
+                        size=$base
+                    fi
+                    sliced=("${suites[@]:start:size}")
+                    echo "ROBOT_SUITES=${sliced[*]}" >> "$GITHUB_ENV"
+                    echo "Shard ${SHARD}/${TOTAL}: ${size} of ${n} suites"
+
             -   name: Boot Project
                 run: |
                     git clone --depth 1 https://github.com/spryker/docker-sdk.git ./docker
@@ -46,18 +109,31 @@ jobs:
             -   uses: ./.github/actions/setup-etc-hosts
 
             -   name: Install Project
+                # Build-once: restore the shared full_EU dump via ci.restore-db.stage2 instead
+                # of importing demodata per shard. The deploy file's own pipeline key is
+                # untouched; only SPRYKER_PIPELINE is overridden for this invocation.
+                env:
+                    SPRYKER_PIPELINE: ci.restore-db.stage2
                 run: |
                     docker/sdk up -t
                     docker/sdk cli composer dump-autoload -o -a --apcu
 
+            -   name: Validate sync completeness
+                uses: ./.github/actions/validate-sync-completeness
+
             -   name: Run Tests
+                if: env.ROBOT_SUITES != ''
+                # --name Suites pins the root suite name: with the slice passed as explicit
+                # suite arguments robot would otherwise derive a root name from the file list,
+                # which changes per shard and breaks longname-based post-processing.
                 run: |
-                    docker/sdk exec robot-framework robot -v env:api_b2c -v docker:True -v dms:true -v glue_env:http://glue.eu.spryker.local -v bapi_env:http://glue-backend.eu.spryker.local -v sapi_env:http://glue-storefront.eu.spryker.local --exclude skip-due-to-issueORskip-due-to-refactoring -d results -s robotframework.tests.api.b2c .
+                    read -ra suites <<< "$ROBOT_SUITES"
+                    docker/sdk exec robot-framework robot -v env:api_b2c -v docker:True -v dms:true -v glue_env:http://glue.eu.spryker.local -v bapi_env:http://glue-backend.eu.spryker.local -v sapi_env:http://glue-storefront.eu.spryker.local --exclude skip-due-to-issueORskip-due-to-refactoring -d results --name Suites --runemptysuite "${suites[@]}"
 
             -   name: Upload artifacts
                 if: failure()
                 run: |
-                    AWS_DEFAULT_REGION=${{env.ROBOT_TESTS_ARTIFACTS_BUCKET_REGION}} AWS_ACCESS_KEY_ID=${{ secrets.ROBOT_TESTS_ARTIFACTS_KEY }} AWS_SECRET_ACCESS_KEY=${{ secrets.ROBOT_TESTS_ARTIFACTS_SECRET }} aws s3 cp .robot/results/log.html s3://${{vars.ROBOT_TESTS_ARTIFACTS_BUCKET}}/b2c/dms-on/robot-api/${GITHUB_RUN_ID}/PHP8.4MariaDB/log.html
+                    AWS_DEFAULT_REGION=${{env.ROBOT_TESTS_ARTIFACTS_BUCKET_REGION}} AWS_ACCESS_KEY_ID=${{ secrets.ROBOT_TESTS_ARTIFACTS_KEY }} AWS_SECRET_ACCESS_KEY=${{ secrets.ROBOT_TESTS_ARTIFACTS_SECRET }} aws s3 cp .robot/results/log.html s3://${{vars.ROBOT_TESTS_ARTIFACTS_BUCKET}}/b2c/dms-on/robot-api/${GITHUB_RUN_ID}/PHP8.4MariaDB/shard-${{ matrix.shard.shard }}/log.html
 
             -   name: Slack Notification for failed job
                 uses: ./.github/actions/job-slack-notifications

--- a/.github/workflows/_robot-ui.yml
+++ b/.github/workflows/_robot-ui.yml
@@ -160,15 +160,20 @@ jobs:
                 # rebot exits with the number of failed tests, so a non-success outcome here is
                 # the signal that a rerun is needed. It also rejects a zero-test source, so guard
                 # the empty-phase case rather than letting the merge itself fail for that reason.
+                #
+                # The counting runs on the RUNNER, against the bind-mounted results dir: the
+                # robot image has no `python` (only `python3`), and `docker/sdk exec` re-splits
+                # its arguments through `sh -c`, so an in-container interpreter snippet is
+                # doubly unreliable. Getting this wrong is silent — a broken count makes every
+                # branch fall through, the step still exits 0, the rerun is skipped, and a shard
+                # with failed tests reports green.
                 run: |
+                    sudo chmod -R a+rX .robot/results 2>/dev/null || true
                     count_tests() {
-                        docker/sdk exec robot-framework python -c "
-                    import xml.etree.ElementTree as ET, sys
-                    try: print(len(ET.parse(sys.argv[1]).findall('.//test')))
-                    except Exception: print(0)" "$1" 2>/dev/null || echo 0
+                        python3 -c 'import os, sys, xml.etree.ElementTree as ET; p = sys.argv[1]; print(len(ET.parse(p).findall(".//test")) if os.path.isfile(p) else 0)' "$1" 2>/dev/null || echo 0
                     }
-                    DYNAMIC_TESTS=$(count_tests results/dynamic_set/output.xml)
-                    STATIC_TESTS=$(count_tests results/static_set/output.xml)
+                    DYNAMIC_TESTS=$(count_tests .robot/results/dynamic_set/output.xml)
+                    STATIC_TESTS=$(count_tests .robot/results/static_set/output.xml)
                     echo "Dynamic: ${DYNAMIC_TESTS} test(s); Static: ${STATIC_TESTS} test(s)"
                     if [ "${DYNAMIC_TESTS:-0}" -gt 0 ] && [ "${STATIC_TESTS:-0}" -gt 0 ]; then
                         docker/sdk exec robot-framework rebot -d results --output output.xml --merge results/dynamic_set/output.xml results/static_set/output.xml

--- a/.github/workflows/_robot-ui.yml
+++ b/.github/workflows/_robot-ui.yml
@@ -12,10 +12,39 @@ env:
     ROBOT_TESTS_ARTIFACTS_BUCKET_REGION: eu-west-1
 
 jobs:
-    robot-ui:
-        name: "Robot / UI"
-        timeout-minutes: 60
+    # Pure matrix-compute job (bash only) — emits ROBOT_SHARD_COUNT shards as
+    # {label,shard,total} JSON. The per-shard file slice is computed in the test job,
+    # where the installed suite tree is available to walk.
+    robot-ui-shards:
+        name: "Robot UI shards"
+        timeout-minutes: 2
         runs-on: ubuntu-latest
+        outputs:
+            shards: ${{ steps.compute.outputs.shards }}
+        steps:
+            -   id: compute
+                env:
+                    ROBOT_SHARD_COUNT: "3"
+                run: |
+                    n="${ROBOT_SHARD_COUNT}"
+                    SHARDS="["
+                    for i in $(seq 1 "$n"); do
+                        [ "$i" -gt 1 ] && SHARDS="${SHARDS},"
+                        SHARDS="${SHARDS}{\"label\":\"${i}/${n}\",\"shard\":${i},\"total\":${n}}"
+                    done
+                    SHARDS="${SHARDS}]"
+                    echo "shards=${SHARDS}" >> "$GITHUB_OUTPUT"
+                    echo "Computed Robot UI shards: ${SHARDS}"
+
+    robot-ui:
+        name: "Robot / UI ${{ matrix.shard.label }}"
+        timeout-minutes: 60
+        needs: robot-ui-shards
+        runs-on: ubuntu-latest
+        strategy:
+            fail-fast: false
+            matrix:
+                shard: ${{ fromJson(needs.robot-ui-shards.outputs.shards) }}
         env:
             PROGRESS_TYPE: plain
             SPRYKER_PLATFORM_IMAGE: spryker/php:8.4
@@ -23,8 +52,14 @@ jobs:
             ROBOT_TESTS_ARTIFACTS_BUCKET_REGION: eu-west-1
             SPRYKER_CURRENT_REGION: EU
             DYNAMIC_STORE_MODE: true
+            TEST_SET: parallel_ui/b2c
         steps:
             -   uses: actions/checkout@v4
+
+            # Must land before the boot so the dump is part of the baked image.
+            -   uses: actions/download-artifact@v6
+                with:
+                    name: spryker-app-db
 
             -   name: Install packages
                 run: |
@@ -38,6 +73,37 @@ jobs:
                     cd ./data && composer require "spryker/robotframework-suite-tests:dev-release_202512.0_state" --dev --no-interaction
                     cp -r vendor ../vendor
 
+            -   name: Compute shard slice
+                env:
+                    SHARD: ${{ matrix.shard.shard }}
+                    TOTAL: ${{ matrix.shard.total }}
+                run: |
+                    # Suite files live directly under tests/<set>/** (no /suite/ subdir). Strip
+                    # the vendor package prefix so the paths resolve inside the robot-framework
+                    # container, whose cwd is the mounted package root (/opt/robotframework).
+                    # The static-set tagged file (misc/static_demodata_set.robot) is one of
+                    # these, so it lands in exactly one shard's slice and the static phase
+                    # produces tests only there; the merge guard below covers the empty phases.
+                    mapfile -t suites < <(find vendor -type f -path "*/tests/${TEST_SET}/*.robot" \
+                        | LC_ALL=C sort \
+                        | sed 's|^vendor/spryker/robotframework-suite-tests/||')
+
+                    # Remainder-distribution slice: the first (n % TOTAL) shards take one extra
+                    # file, so every file lands in exactly one shard.
+                    n=${#suites[@]}
+                    base=$(( n / TOTAL ))
+                    extra=$(( n % TOTAL ))
+                    if (( SHARD - 1 < extra )); then
+                        start=$(( (SHARD - 1) * (base + 1) ))
+                        size=$(( base + 1 ))
+                    else
+                        start=$(( extra * (base + 1) + (SHARD - 1 - extra) * base ))
+                        size=$base
+                    fi
+                    sliced=("${suites[@]:start:size}")
+                    echo "ROBOT_SUITES=${sliced[*]}" >> "$GITHUB_ENV"
+                    echo "Shard ${SHARD}/${TOTAL}: ${size} of ${n} suites"
+
             -   name: Boot Project
                 run: |
                     git clone --depth 1 https://github.com/spryker/docker-sdk.git ./docker
@@ -47,21 +113,46 @@ jobs:
             -   uses: ./.github/actions/setup-etc-hosts
 
             -   name: Install Project
+                # Build-once: restore the shared full_EU dump via ci.restore-db.stage2 instead
+                # of importing demodata per shard. The deploy file's own pipeline key is
+                # untouched; only SPRYKER_PIPELINE is overridden for this invocation.
+                env:
+                    SPRYKER_PIPELINE: ci.restore-db.stage2
                 run: |
                     docker/sdk up -t
                     docker/sdk cli composer dump-autoload -o -a --apcu
 
+            -   name: Validate sync completeness
+                uses: ./.github/actions/validate-sync-completeness
+
+            -   name: Pre-warm Yves Twig cache
+                # The restore pipeline's twig warmers don't compile CMS string templates (built
+                # lazily by the CMS content renderer on first render), so pabot workers race on
+                # Twig's FilesystemCache::mkdir. One sequential render compiles it up front.
+                run: |
+                    docker/sdk exec robot-framework curl -sf http://yves.eu.spryker.local/ -o /dev/null || true
+
             -   name: Run Dynamic Tests Set
                 id: run_dynamic_tests
+                if: env.ROBOT_SUITES != ''
                 continue-on-error: true
+                # --name Suites pins the root suite name: with the slice passed as explicit
+                # suite arguments robot/pabot would otherwise derive a per-shard root name,
+                # which breaks the longnames rebot --merge and --rerunfailed rely on.
                 run: |
-                    docker/sdk exec robot-framework pabot --processes 6 --ordering pabot_b2c_ordering -v env:ui_b2c -v docker:True -v headless:true -v ignore_console:false -v dms:true -d results/dynamic_set --exclude skip-due-to-issueORskip-due-to-refactoringORstatic-set -s '*'.tests.parallel_ui.b2c .
+                    read -ra suites <<< "$ROBOT_SUITES"
+                    docker/sdk exec robot-framework pabot --processes 6 -v env:ui_b2c -v docker:True -v headless:true -v ignore_console:false -v dms:true -d results/dynamic_set --name Suites --exclude skip-due-to-issueORskip-due-to-refactoringORstatic-set --runemptysuite "${suites[@]}"
 
             -   name: Run Static Tests Set
                 id: run_static_tests
+                if: env.ROBOT_SUITES != ''
                 continue-on-error: true
+                # Tag-driven, not path-driven: the dynamic phase above excludes static-set and
+                # this phase includes it, both over the same shard slice — so the single tagged
+                # file runs exactly once, in whichever shard's slice holds it.
                 run: |
-                    docker/sdk exec robot-framework robot -v env:ui_b2c -v docker:True -v headless:true -v ignore_console:false -v dms:true -d results/static_set --exclude skip-due-to-issueORskip-due-to-refactoring --include static-set -s '*'.tests.parallel_ui.b2c .
+                    read -ra suites <<< "$ROBOT_SUITES"
+                    docker/sdk exec robot-framework robot -v env:ui_b2c -v docker:True -v headless:true -v ignore_console:false -v dms:true -d results/static_set --name Suites --exclude skip-due-to-issueORskip-due-to-refactoring --include static-set --runemptysuite "${suites[@]}"
 
             -   name: Merge Initial Test Results
                 id: merge_initial_results
@@ -92,10 +183,13 @@ jobs:
             -   name: Rerun Failed Tests
                 id: rerun_failed_tests
                 if: always() && steps.merge_initial_results.outcome != 'success'
-                # The only step without continue-on-error, so it is the job's pass/fail gate:
-                # everything before it is allowed to go red and be retried here.
+                # Re-runs only the failed tests, over the SAME sliced suite files so the
+                # --rerunfailed longnames resolve. The only step without continue-on-error, so
+                # it is the job's pass/fail gate: everything before it may go red and be retried
+                # here.
                 run: |
-                    docker/sdk exec robot-framework robot -v env:ui_b2c -v docker:True -v dms:true -v headless:true -v ignore_console:false -d results/rerun --runemptysuite --rerunfailed results/output.xml --output rerun.xml -s '*'.tests.parallel_ui.b2c .
+                    read -ra suites <<< "$ROBOT_SUITES"
+                    docker/sdk exec robot-framework robot -v env:ui_b2c -v docker:True -v dms:true -v headless:true -v ignore_console:false -d results/rerun --name Suites --runemptysuite --rerunfailed results/output.xml --output rerun.xml "${suites[@]}"
 
             -   name: Merge Final Test Results
                 if: always() && steps.rerun_failed_tests.outcome != 'skipped'
@@ -108,7 +202,7 @@ jobs:
                 # passed on rerun leaves the job green, and its log.html is the only evidence.
                 if: always() && steps.rerun_failed_tests.outcome != 'skipped'
                 run: |
-                    AWS_DEFAULT_REGION=${{env.ROBOT_TESTS_ARTIFACTS_BUCKET_REGION}} AWS_ACCESS_KEY_ID=${{ secrets.ROBOT_TESTS_ARTIFACTS_KEY }} AWS_SECRET_ACCESS_KEY=${{ secrets.ROBOT_TESTS_ARTIFACTS_SECRET }} aws s3 cp .robot/results/log.html s3://${{vars.ROBOT_TESTS_ARTIFACTS_BUCKET}}/b2c/dms-on/robot-ui/${GITHUB_RUN_ID}/PHP8.4MariaDB/log.html
+                    AWS_DEFAULT_REGION=${{env.ROBOT_TESTS_ARTIFACTS_BUCKET_REGION}} AWS_ACCESS_KEY_ID=${{ secrets.ROBOT_TESTS_ARTIFACTS_KEY }} AWS_SECRET_ACCESS_KEY=${{ secrets.ROBOT_TESTS_ARTIFACTS_SECRET }} aws s3 cp .robot/results/log.html s3://${{vars.ROBOT_TESTS_ARTIFACTS_BUCKET}}/b2c/dms-on/robot-ui/${GITHUB_RUN_ID}/PHP8.4MariaDB/shard-${{ matrix.shard.shard }}/log.html
 
             -   name: Slack Notification for failed job
                 uses: ./.github/actions/job-slack-notifications

--- a/.github/workflows/ci-focused.yml
+++ b/.github/workflows/ci-focused.yml
@@ -19,23 +19,33 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.inputs.framework }}
     cancel-in-progress: true
 
+# Every consumer restores the same build-once full_EU dump, so the build job runs for every
+# framework choice — there is only one data flavour in this shop.
 jobs:
+    build-db:
+        uses: ./.github/workflows/_build-db.yml
+        secrets: inherit
+
     codeception:
+        needs: [build-db]
         if: ${{ inputs.framework == 'codeception' }}
         uses: ./.github/workflows/_codeception.yml
         secrets: inherit
 
     robot-api:
+        needs: [build-db]
         if: ${{ inputs.framework == 'robot-api' }}
         uses: ./.github/workflows/_robot-api.yml
         secrets: inherit
 
     robot-ui:
+        needs: [build-db]
         if: ${{ inputs.framework == 'robot-ui' }}
         uses: ./.github/workflows/_robot-ui.yml
         secrets: inherit
 
     cypress:
+        needs: [build-db]
         if: ${{ inputs.framework == 'cypress' }}
         uses: ./.github/workflows/_cypress.yml
         secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,27 +225,35 @@ jobs:
                 uses: ./.github/actions/job-slack-notifications
                 if: always()
 
+    # Imports full_EU once and publishes the dump as the `spryker-app-db` artifact. Every
+    # test consumer restores it via SPRYKER_PIPELINE=ci.restore-db.stage2 instead of
+    # importing demodata itself, so the import cost is paid once per run rather than per job.
+    build-db:
+        needs: [js-validation]
+        uses: ./.github/workflows/_build-db.yml
+        secrets: inherit
+
     codeception:
-        needs: [validation, js-validation]
+        needs: [validation, js-validation, build-db]
         uses: ./.github/workflows/_codeception.yml
         secrets: inherit
 
     # The E2E tier is skipped while a PR is a draft and starts on ready_for_review. A push to
     # master is not a pull_request event, so master keeps running the full set.
     robot-api:
-        needs: [validation]
+        needs: [validation, build-db]
         if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
         uses: ./.github/workflows/_robot-api.yml
         secrets: inherit
 
     robot-ui:
-        needs: [validation, js-validation]
+        needs: [validation, js-validation, build-db]
         if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
         uses: ./.github/workflows/_robot-ui.yml
         secrets: inherit
 
     cypress:
-        needs: [validation, js-validation]
+        needs: [validation, js-validation, build-db]
         if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
         uses: ./.github/workflows/_cypress.yml
         secrets: inherit

--- a/.github/workflows/scripts/generate-cypress-shards.py
+++ b/.github/workflows/scripts/generate-cypress-shards.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""Generate the Cypress shard matrix at runtime from recorded spec timings.
+
+The installed `cypress-tests` package (composer-installed, gitignored) is the
+single source of truth for which specs exist; this script lists them, balances
+them across a FIXED number of shards by measured runtime, and prints the matrix
+the `cypress` job consumes.
+
+Pipeline
+--------
+1. List installed specs under ``<package-dir>/cypress/e2e/**/*.cy.ts``,
+   excluding ``smoke/`` and any ``ssp*`` basename — the same filter the CI spec
+   glob applies (SSP runs as its own standalone shard).
+2. Load a timings file (``cypress-timings.json``: ``{spec: duration_ms}``) if
+   present. New/untimed specs are assigned the mean of the known durations so
+   a freshly added spec is placed sensibly instead of always landing in shard
+   one.
+3. LPT (longest-processing-time) bin-pack the specs by duration into a fixed
+   ``N`` shards: sort longest first, drop each onto the currently-lightest
+   shard. This is the standard greedy makespan heuristic — it keeps per-shard
+   wall time close without needing an exact solver.
+4. Self-check: assert the union of the shard spec lists equals the installed
+   spec set (no drops, no dupes). A mismatch means a generator bug, so we
+   ``exit 1`` (plain, no run-cancel) — the ONLY red path. Adding a spec cannot
+   trigger it; the spec is absorbed into a shard automatically.
+
+Fallback
+--------
+If the timings file is missing, empty, or corrupt, every spec is treated as
+equal cost (count-based packing) and a GitHub ``::notice::`` is logged. Timing
+data is advisory only: its absence or corruption degrades balance but never
+fails the gate.
+
+Output
+------
+Prints a JSON array to stdout: one entry per core shard plus a trailing SSP
+entry, in the exact shape the ``cypress`` matrix already expects
+(``label``/``shard``/``total``/``specs``/``mode``). The gate job captures
+stdout into ``$GITHUB_OUTPUT``.
+
+Usage
+-----
+    generate-cypress-shards.py [--package-dir DIR] [--timings FILE] [--shards N]
+                               [--include-ssp]
+
+Defaults: package-dir=tests/cypress-tests, timings=cypress-timings.json, N=5,
+include-ssp=off. The SSP shard is opt-in: this shop runs no SSP lane, and emitting
+one would execute a spec set that is not part of the baseline.
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import os
+import sys
+from pathlib import Path
+
+DEFAULT_PACKAGE_DIR = "tests/cypress-tests"
+DEFAULT_TIMINGS_FILE = "cypress-timings.json"
+DEFAULT_SHARD_COUNT = 5
+E2E_GLOB = "cypress/e2e/**/*.cy.ts"
+
+
+def log_notice(message: str) -> None:
+    """Emit a GitHub Actions notice (harmless plain line off CI)."""
+    print(f"::notice::{message}", file=sys.stderr)
+
+
+def list_installed_specs(package_dir: str) -> list[str]:
+    """Return sorted core spec paths relative to the package root.
+
+    Glob under the package, excluding any path containing ``/smoke/`` or whose
+    basename starts with ``ssp`` (SSP runs as its own standalone shard).
+    """
+    specs: list[str] = []
+    cwd = Path.cwd()
+    os.chdir(package_dir)
+    try:
+        for p in glob.iglob(E2E_GLOB, recursive=True):
+            if "/smoke/" in p or os.path.basename(p).startswith("ssp"):
+                continue
+            specs.append(p)
+    finally:
+        os.chdir(cwd)
+    return sorted(specs)
+
+
+def load_timings(timings_file: str) -> dict[str, float] | None:
+    """Load ``{spec: duration_ms}``; return None on any missing/corrupt input.
+
+    A None return is the caller's signal to fall back to count-based packing.
+    """
+    if not timings_file or not os.path.isfile(timings_file):
+        return None
+    try:
+        with open(timings_file) as f:
+            data = json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return None
+    if not isinstance(data, dict) or not data:
+        return None
+    timings: dict[str, float] = {}
+    for spec, duration in data.items():
+        try:
+            value = float(duration)
+        except (TypeError, ValueError):
+            continue
+        if value > 0:
+            timings[str(spec)] = value
+    return timings or None
+
+
+def spec_durations(
+    specs: list[str], timings: dict[str, float] | None
+) -> tuple[dict[str, float], bool]:
+    """Map each spec to a duration; second value is True when count-based.
+
+    With timings present, untimed specs get the mean of the known durations.
+    With no usable timings, every spec is weighted equally (count-based).
+    """
+    if not timings:
+        return {spec: 1.0 for spec in specs}, True
+
+    known = [timings[spec] for spec in specs if spec in timings]
+    mean = (sum(known) / len(known)) if known else 1.0
+    return {spec: timings.get(spec, mean) for spec in specs}, False
+
+
+def pack_shards(specs: list[str], durations: dict[str, float], shard_count: int) -> list[list[str]]:
+    """LPT bin-pack specs into ``shard_count`` bins, balancing total duration.
+
+    Sort longest-first (stable tie-break on spec name for determinism), then
+    drop each spec onto the currently-lightest bin (lowest index breaks ties).
+    """
+    bins: list[list[str]] = [[] for _ in range(shard_count)]
+    loads = [0.0] * shard_count
+    ordered = sorted(specs, key=lambda s: (-durations[s], s))
+    for spec in ordered:
+        target = min(range(shard_count), key=lambda i: (loads[i], i))
+        bins[target].append(spec)
+        loads[target] += durations[spec]
+    # Keep each bin's spec list stable/readable.
+    for b in bins:
+        b.sort()
+    return bins
+
+
+def build_matrix(bins: list[list[str]], include_ssp: bool = False) -> list[dict[str, str | int]]:
+    """Render the bins as the matrix entries the ``cypress`` job consumes."""
+    total = len(bins)
+    matrix: list[dict[str, str | int]] = []
+    for index, shard_specs in enumerate(bins, start=1):
+        matrix.append(
+            {
+                "label": f"{index}/{total}",
+                "shard": str(index),
+                "total": total,
+                "specs": ",".join(shard_specs),
+                "mode": "core",
+            }
+        )
+    # SSP folded into the matrix as its own shard: one less standalone
+    # full-env bring-up; SSP coverage preserved. Handling is unchanged.
+    # Opt-in, because shops with no SSP lane must not be handed an SSP shard —
+    # it would run a spec set they never ran before.
+    if include_ssp:
+        matrix.append(
+            {
+                "label": "ssp",
+                "shard": "ssp",
+                "total": total,
+                "specs": "",
+                "mode": "ssp",
+            }
+        )
+    return matrix
+
+
+def self_check(installed: list[str], bins: list[list[str]]) -> None:
+    """Fail red iff the packed specs don't exactly equal the installed set."""
+    packed: list[str] = [spec for b in bins for spec in b]
+    packed_set = set(packed)
+    installed_set = set(installed)
+
+    if len(packed) != len(packed_set):
+        dupes = sorted({s for s in packed if packed.count(s) > 1})
+        print("Cypress shard generation produced duplicate specs:", file=sys.stderr)
+        for s in dupes:
+            print(f"  ! {s}", file=sys.stderr)
+        sys.exit(1)
+
+    if packed_set != installed_set:
+        missing = sorted(installed_set - packed_set)
+        extra = sorted(packed_set - installed_set)
+        print(
+            "Cypress shard generation self-check FAILED "
+            "(packed specs != installed specs):",
+            file=sys.stderr,
+        )
+        for s in missing:
+            print(f"  - {s} (installed but not packed)", file=sys.stderr)
+        for s in extra:
+            print(f"  + {s} (packed but not installed)", file=sys.stderr)
+        print(
+            "This is a generator bug — investigate the packing logic.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+def generate(
+    package_dir: str, timings_file: str, shard_count: int, include_ssp: bool = False
+) -> str:
+    installed = list_installed_specs(package_dir)
+    if not installed:
+        print(
+            f"No Cypress specs found under {package_dir}/{E2E_GLOB} "
+            "(is the cypress-tests package installed?).",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    timings = load_timings(timings_file)
+    durations, count_based = spec_durations(installed, timings)
+    if count_based:
+        log_notice(
+            f"cypress-timings not available at '{timings_file}' — packing "
+            f"{len(installed)} specs into {shard_count} shards by count. "
+            "Balance is approximate until timings are recorded."
+        )
+    else:
+        untimed = [s for s in installed if s not in timings]
+        if untimed:
+            log_notice(
+                f"{len(untimed)} of {len(installed)} specs had no recorded "
+                "timing; assigned the mean duration."
+            )
+
+    bins = pack_shards(installed, durations, shard_count)
+    self_check(installed, bins)
+    return json.dumps(build_matrix(bins, include_ssp))
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--package-dir", default=DEFAULT_PACKAGE_DIR)
+    parser.add_argument("--timings", default=DEFAULT_TIMINGS_FILE)
+    parser.add_argument("--shards", type=int, default=DEFAULT_SHARD_COUNT)
+    parser.add_argument("--include-ssp", action="store_true", default=False)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    if args.shards < 1:
+        print("--shards must be >= 1", file=sys.stderr)
+        return 1
+    print(generate(args.package_dir, args.timings, args.shards, args.include_ssp))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/config/install/ci.restore-db.stage2.yml
+++ b/config/install/ci.restore-db.stage2.yml
@@ -1,0 +1,155 @@
+env:
+    NEW_RELIC_ENABLED: 0
+    SPRYKER_LOG_STDOUT: /dev/null
+
+sections:
+    build:
+        generate-transfers:
+            command: 'vendor/bin/console transfer:generate'
+
+        router-cache-warmup-yves:
+            command: 'vendor/bin/yves router:cache:warm-up'
+
+        router-cache-warmup-backoffice:
+            command: 'vendor/bin/console router:cache:warm-up:backoffice'
+
+        oms-process-cache-warmup:
+            command: 'vendor/bin/console oms:process-cache:warm-up'
+
+        router-cache-warmup-backend-gateway:
+            command: 'vendor/bin/console router:cache:warm-up:backend-gateway'
+
+        twig-cache-warmup:
+            command: 'vendor/bin/console twig:cache:warmer'
+
+        navigation-cache-warmup:
+            command: 'vendor/bin/console navigation:build-cache'
+
+        rest-request-validation-cache-warmup:
+            command: 'vendor/bin/console rest-api:build-request-validation-cache'
+
+        propel-copy-schema:
+            command: 'vendor/bin/console propel:schema:copy'
+
+        propel-build:
+            command: 'vendor/bin/console propel:model:build'
+
+        generate-entity-transfer:
+            command: 'vendor/bin/console transfer:entity:generate'
+
+        generate-page-source-map:
+            command: 'vendor/bin/console search:setup:source-map'
+
+        translator-generate-cache:
+            command: 'vendor/bin/console translator:generate-cache'
+
+        cache-class-resolver-build:
+            command: 'vendor/bin/console cache:class-resolver:build'
+
+        generate-scope-collection-file:
+            command: 'vendor/bin/console oauth:scope-collection-file:generate'
+
+    build-development:
+        generate-transfers:
+            command: 'vendor/bin/console transfer:generate'
+
+        generate-transfer-databuilders:
+            command: 'vendor/bin/console transfer:databuilder:generate'
+
+        rest-api-generate-documentation:
+            command: 'vendor/bin/console rest-api:generate:documentation'
+
+    build-static:
+        dependencies-install:
+            command: 'vendor/bin/console frontend:project:install-dependencies'
+
+    build-static-production:
+        excluded: true
+        yves-build-frontend:
+            command: 'vendor/bin/console frontend:yves:build -e production'
+
+        zed-build-frontend:
+            command: 'vendor/bin/console frontend:zed:build -e production'
+
+        date-time-product-configurator:
+            command: 'vendor/bin/console frontend:date-time-product-configurator:build'
+
+    build-static-development:
+        yves-build-frontend:
+            command: 'vendor/bin/console frontend:yves:build'
+
+        zed-build-frontend:
+            command: 'vendor/bin/console frontend:zed:build'
+
+        date-time-product-configurator:
+            command: 'vendor/bin/console frontend:date-time-product-configurator:build'
+
+    init-storages-per-store:
+        queue-setup:
+            command: 'vendor/bin/console queue:setup'
+        setup-search-create-sources:
+            command: 'vendor/bin/console search:setup:sources'
+
+    init-storages-per-region:
+        queue-setup:
+            command: 'vendor/bin/console queue:setup'
+
+        propel-copy-schema:
+            command: 'vendor/bin/console propel:schema:copy'
+
+        propel-postgres-compatibility:
+            command: 'vendor/bin/console propel:pg-sql-compat'
+
+        propel-migration-delete:
+            command: 'vendor/bin/console propel:migration:delete'
+
+        propel-tables-drop:
+            command: 'vendor/bin/console propel:tables:drop'
+
+        propel-diff:
+            command: 'vendor/bin/console propel:diff'
+
+        propel-migrate:
+            command: 'vendor/bin/console propel:migrate'
+
+        propel-migration-cleanup:
+            command: 'vendor/bin/console propel:migration:delete'
+
+        init-database:
+            command: 'vendor/bin/console setup:init-db'
+
+    demodata:
+        load-from-file:
+            command: 'mariadb --ssl=false -h $SPRYKER_DB_HOST -u $SPRYKER_DB_USERNAME -p$SPRYKER_DB_PASSWORD $SPRYKER_DB_DATABASE < eu-docker.sql'
+
+        fix-auth-permissions:
+            command: 'vendor/bin/console setup:init-db'
+
+        # requires the restored `spy_store` table
+        setup-search-create-sources:
+            command: 'vendor/bin/console search:setup:sources'
+
+        # The dump carries the SOURCE tables plus the storage/search tables, but ES and
+        # Redis are not in the dump and start empty. `sync:data` alone does not reliably
+        # rebuild them, so re-publish from source the way the original import does
+        # (publish -> drain), then bulk-sync as a backstop, then drain again so no
+        # sync.* queue is left pending. The sync-completeness gate asserts the result.
+        trigger-publish-events:
+            command: 'vendor/bin/console publish:trigger-events'
+
+        publish-and-sync:
+            command: 'vendor/bin/console queue:worker:start --stop-when-empty'
+            timeout: 2000
+
+        sync-data-from-db:
+            command: 'vendor/bin/console sync:data'
+
+        sync-data-drain:
+            command: 'vendor/bin/console queue:worker:start --stop-when-empty'
+            timeout: 2000
+
+        controller-cache-warmup:
+            command: 'vendor/bin/glue glue-api:controller:cache:warm-up'
+
+        api-generate-documentation:
+            command: 'vendor/bin/glue api:generate:documentation'


### PR DESCRIPTION
Stacked on the Phase-1 PR. Second half of the CI adoption for this shop.

- `_build-db` imports `full_EU` once and publishes the dump as the `spryker-app-db` artifact.
- Every test consumer downloads it, boots with `SPRYKER_PIPELINE=ci.restore-db.stage2` and gates on `validate-sync-completeness` instead of importing demodata itself. Deploy files' own `pipeline:` keys are untouched.
- Cypress: runtime shard-manifest job generates a 5-shard matrix from the installed spec tree (LPT pack, count-based until timings exist); self-check keeps the packed set equal to the installed set.
- Robot API shards 2 ways over `tests/api/b2c` (62/62), Robot UI 3 ways over `tests/parallel_ui/b2c` (7/7/6), both by remainder distribution over `LC_ALL=C sort`ed suite files. The single `static-set`-tagged file lands in exactly one shard, so the tag-driven static phase still runs it exactly once.
- S3 failure-artifact destinations carry `shard-<n>/` so shards no longer overwrite each other.

Pins stay `dev-release_202512.0_state`. Executed test set unchanged.

https://spryker.atlassian.net/browse/CC-39284

## Test plan

`gh workflow run ci.yml --ref <this branch>`, twice consecutively green, and parity against the baseline run 30882899068 summed across shards: Cypress 59 specs / 124 tests / 87 passing / 37 pending; Robot API 859 tests (857 passed, 2 skipped); Robot UI dynamic 45/45 plus static set 3/3; Codeception fixtures 41, acceptance 56/148/5 skipped, api 280/1771, functional 85/280/17 skipped.