### PR TITLE
CC-40284: update robot tests version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -267,7 +267,7 @@
         "spryker/cypress-tests": "dev-release_202512.0_state",
         "spryker/docker-chromedriver": "dev-master",
         "spryker/profiler": "^0.1.3",
-        "spryker/robotframework-suite-tests": "dev-master",
+        "spryker/robotframework-suite-tests": "dev-release_202512.0_state",
         "spryker/testify": "^3.66.3",
         "spryker/testify-backend-api": "^0.1.3",
         "stecman/symfony-console-completion": ">=0.15",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bf935feae7b271980fe56d807a7308ee",
+    "content-hash": "ef6bc571735e5f891b66fc1da410fb62",
     "packages": [
         {
             "name": "async-aws/core",
@@ -66216,13 +66216,12 @@
         },
         {
             "name": "spryker/robotframework-suite-tests",
-            "version": "dev-master",
+            "version": "dev-release_202512.0_state",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/robotframework-suite-tests.git",
-                "reference": "f8890f0c53d6a5f19b3e1ed7fbe480ff390ce420"
+                "reference": "3c33c77a11e97b7bd6532e7f7b495dca8423e492"
             },
-            "default-branch": true,
             "bin": [
                 "bin/run-robot-suite-tests.sh"
             ],
@@ -66231,7 +66230,7 @@
                 "MIT"
             ],
             "description": "Automated tests for the Robot Framework",
-            "time": "2026-08-25T15:38:03+00:00"
+            "time": "2026-08-25T23:00:34+00:00"
         },
         {
             "name": "spryker/testify",


### PR DESCRIPTION
#### Overview

- Ticket: https://spryker.atlassian.net/browse/CC-40284

###### Change log

{Relevant changes for project level go here.}

###### CI Notice
Tests do **not** run automatically on every PR.
To trigger the required test suites, please add the appropriate label(s) to your PR.
For the full list of labels and their associated tests, see our Confluence page: [CI Test Labels & Triggers](https://spryker.atlassian.net/wiki/spaces/Framework/pages/4715216905/Using+PR+labels+to+control+CI+runs+for+project+repositories)
